### PR TITLE
Bump patch version of some dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -49,9 +49,9 @@ Gravitee BOM includes latest versions of development dependencies. It means that
 
 DO NOT MOVE TO Gravitee BOM unless you are confident about the compatibility of the dependencies declared in the bom. The most significant dependencies are:
 
-- *vertx 4.2.4*
-- *netty 4.1.72.Final*
-- *spring 5.3.15*
+- *vertx 4.2.6*
+- *netty 4.1.74.Final*
+- *spring 5.3.18*
 
 Basically, you should consider migrating to gravitee-bom starting from 3.10.0 of Gravitee.
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,22 +61,22 @@
 
     <properties>
         <assertj-core.version>3.22.0</assertj-core.version>
-        <jackson.version>2.12.6</jackson.version>
+        <jackson.version>2.13.2.1</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <mockito-junit-jupiter.version>3.12.4</mockito-junit-jupiter.version>
-        <logback.version>1.2.10</logback.version>
+        <logback.version>1.2.11</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>3.11.2</mockito.version>
-        <netty.version>4.1.72.Final</netty.version>
+        <netty.version>4.1.74.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <rxjava.version>2.2.21</rxjava.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <spring.version>5.3.15</spring.version>
-        <spring-security.version>5.5.4</spring-security.version>
-        <vertx.version>4.2.4</vertx.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <spring.version>5.3.18</spring.version>
+        <spring-security.version>5.5.5</spring-security.version>
+        <vertx.version>4.2.6</vertx.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Bump patch version for the following dependencies: 
 - logback
 - slf4j
 - spring
 - spring security
 - vertx

Aligned Jackson (move to 2.13) and Netty (minor patch) to the version defined in `vertx-dependencies` pom:
 
![image](https://user-images.githubusercontent.com/4112568/163198396-104e0ee1-9a28-411a-88d6-ead32884296e.png)