### PR TITLE
fix: must add the version since it is in dependency management

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,7 @@ parameters:
 
 orbs:
   slack: circleci/slack@4.8.2
-  gravitee: gravitee-io/gravitee@1.0.44
-  # gravitee: gravitee-io/gravitee@dev:1.0.21
-  secrethub: secrethub/cli@1.1.0
-  # secrethub: secrethub/cli@1.0.0
+  gravitee: gravitee-io/gravitee@1.0.46
 
 workflows:
   version: 2.1

--- a/pom.xml
+++ b/pom.xml
@@ -224,11 +224,13 @@
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit-jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-params</artifactId>
+                <version>${junit-jupiter.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Usage of `mvn versions:use-releases` in projects using 2.3 or 2.4 version of BOM fails because there is no version declared in some dependency.
