### PR TITLE
chore(deps): update spring security version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ parameters:
     description: "Used only for the Gravitee Parent Release Process: What will be the next snapshot version?"
 
 orbs:
-  slack: circleci/slack@4.2.1
+  slack: circleci/slack@4.8.2
   gravitee: gravitee-io/gravitee@1.0.44
   # gravitee: gravitee-io/gravitee@dev:1.0.21
   secrethub: secrethub/cli@1.1.0

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -5,9 +5,9 @@ Here are few guidelines that should help you get started.
 
 == Using GitHub issues
 
-We use GitHub issues to track bugs and enhancements. Found a bug in the source code? You want to propose new features or enhancements  You can help us by submitting an issue in our https://github.com/gravitee-io/gravitee-bom[repository]. Before you submit your issue, search the https://github.com/gravitee-io/issues/issues[issues archive] or the https://waffle.io/gravitee-io/release[backlog]; maybe your question was already answered.
+We use GitHub issues to track bugs and enhancements. Found a bug in the source code? You want to propose new features or enhancements  You can help us by submitting an issue in our https://github.com/gravitee-io/gravitee-bom[repository]. Before you submit your issue, search the https://github.com/gravitee-io/issues/issues[issues repository]; maybe your question was already answered.
 
-> Issues are only to report bugs, request enhancements, or request new features. For general questions and discussions, use the https://gitter.im/gravitee-io/gravitee-io[Gravitee.io Gitter chat].
+> Issues are only to report bugs, request enhancements, or request new features. For general questions and discussions, use the image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=contributing", height=20].
 
 Providing the following information will help us to deal quickly with your issue :
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jackson.version>2.12.5</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
-        <junit.version>4.13.1</junit.version>
+        <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <mockito-junit-jupiter.version>3.12.4</mockito-junit-jupiter.version>
         <logback.version>1.2.5</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-bom</artifactId>
-    <version>2.0</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>gravitee-bom</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </organization>
 
     <properties>
-        <assertj-core.version>3.20.2</assertj-core.version>
+        <assertj-core.version>3.22.0</assertj-core.version>
         <jackson.version>2.12.5</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.43.v20210629</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <rxjava.version>2.2.21</rxjava.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>5.3.18</spring.version>
-        <spring-security.version>5.5.5</spring-security.version>
+        <spring-security.version>5.5.7</spring-security.version>
         <vertx.version>4.2.7</vertx.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.43.v20210629</jetty.version>
         <junit.version>4.13.1</junit.version>
-        <junit-jupiter.version>5.7.2</junit-jupiter.version>
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <mockito-junit-jupiter.version>3.12.4</mockito-junit-jupiter.version>
         <logback.version>1.2.5</logback.version>
         <logback-json.version>0.1.5</logback-json.version>


### PR DESCRIPTION
## Description

Bump Spring Security version

Please see the following links to knows what are the updates:
👉🏼 https://github.com/spring-projects/spring-security/releases/tag/5.5.6
👉🏼 https://github.com/spring-projects/spring-security/releases/tag/5.5.7