### PR TITLE
Revert "Bump Vertx, Jackson, Netty, Spring, Spring Security and AssertJ #51"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.5</rxjava3.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <spring.version>5.3.25</spring.version>
-        <spring-security.version>5.5.8</spring-security.version>
+        <spring.version>5.3.18</spring.version>
+        <spring-security.version>5.5.7</spring-security.version>
         <vertx.version>4.3.8</vertx.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </organization>
 
     <properties>
-        <assertj-core.version>3.24.2</assertj-core.version>
+        <assertj-core.version>3.22.0</assertj-core.version>
         <jackson.version>2.14.0</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
     <properties>
         <assertj-core.version>3.22.0</assertj-core.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson.version>2.13.2.1</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <junit.version>4.13.2</junit.version>
@@ -70,14 +70,14 @@
         <logback.version>1.2.11</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>3.11.2</mockito.version>
-        <netty.version>4.1.87.Final</netty.version>
+        <netty.version>4.1.74.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.5</rxjava3.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>5.3.18</spring.version>
         <spring-security.version>5.5.7</spring-security.version>
-        <vertx.version>4.3.8</vertx.version>
+        <vertx.version>4.2.7</vertx.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

NA

**Description**

Revert https://github.com/gravitee-io/gravitee-bom/pull/51 due to an issue with Vert.x update; a version 4.0.0 will be done instead.