### PR TITLE
Bump `vertx`, `jackson`, `netty` and a couple of other deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     </organization>
 
     <properties>
-        <assertj-core.version>3.22.0</assertj-core.version>
+        <assertj-core.version>3.24.2</assertj-core.version>
         <jackson.version>2.14.0</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,8 @@
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.5</rxjava3.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <spring.version>5.3.18</spring.version>
-        <spring-security.version>5.5.7</spring-security.version>
+        <spring.version>5.3.25</spring.version>
+        <spring-security.version>5.5.8</spring-security.version>
         <vertx.version>4.3.8</vertx.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <spring.version>5.3.25</spring.version>
         <spring-security.version>5.5.8</spring-security.version>
         <vertx.version>4.3.8</vertx.version>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.26</lombok.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>3.11.2</mockito.version>
         <netty.version>4.1.87.Final</netty.version>
-        <reactive-streams.version>1.0.3</reactive-streams.version>
+        <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.6</rxjava3.version>
         <slf4j.version>1.7.36</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <junit.version>4.13.2</junit.version>
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
+        <junit-jupiter.version>5.9.2</junit-jupiter.version>
         <mockito-junit-jupiter.version>3.12.4</mockito-junit-jupiter.version>
         <logback.version>1.2.11</logback.version>
         <logback-json.version>0.1.5</logback-json.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
     <properties>
         <assertj-core.version>3.22.0</assertj-core.version>
-        <jackson.version>2.13.2.1</jackson.version>
+        <jackson.version>2.14.0</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <junit.version>4.13.2</junit.version>
@@ -70,14 +70,14 @@
         <logback.version>1.2.11</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>3.11.2</mockito.version>
-        <netty.version>4.1.74.Final</netty.version>
+        <netty.version>4.1.87.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.5</rxjava3.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>5.3.18</spring.version>
         <spring-security.version>5.5.7</spring-security.version>
-        <vertx.version>4.2.7</vertx.version>
+        <vertx.version>4.3.8</vertx.version>
         <lombok.version>1.18.24</lombok.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <netty.version>4.1.87.Final</netty.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <rxjava2.version>2.2.21</rxjava2.version>
-        <rxjava3.version>3.1.5</rxjava3.version>
+        <rxjava3.version>3.1.6</rxjava3.version>
         <slf4j.version>1.7.36</slf4j.version>
         <spring.version>5.3.25</spring.version>
         <spring-security.version>5.5.8</spring-security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
     <properties>
         <assertj-core.version>3.24.2</assertj-core.version>
-        <jackson.version>2.14.0</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
         <jersey.version>2.35</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
**Issue**

NA

**Description**

Versions for `jackson` and `netty` are the ones defined in `vertx-dependencies`

BREAKING CHANGE: Vert.x update might contain breaking changes.

Other dependencies will be updated in another PR
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-dep-major-update-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/4.0.0-dep-major-update-SNAPSHOT/gravitee-bom-4.0.0-dep-major-update-SNAPSHOT.zip)
  <!-- Version placeholder end -->
