### PR TITLE
bump mockito version to latest and use bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,10 +66,9 @@
         <jetty.version>9.4.44.v20210927</jetty.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.9.2</junit-jupiter.version>
-        <mockito-junit-jupiter.version>3.12.4</mockito-junit-jupiter.version>
         <logback.version>1.2.11</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
-        <mockito.version>3.11.2</mockito.version>
+        <mockito.version>5.1.1</mockito.version>
         <netty.version>4.1.87.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava2.version>2.2.21</rxjava2.version>
@@ -151,6 +150,14 @@
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -247,12 +254,6 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-junit-jupiter</artifactId>
-                <version>${mockito-junit-jupiter.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>${assertj-core.version}</version>
@@ -261,6 +262,18 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
                 <version>${mockito.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8257

**Description**

 - Bump mockito version to latest version 5.1.1
 - Import mockito bom
 - Declare mockito-core, mockito-inline, and mockito-junit-jupiter in dependencies managment
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-8257-update-mockito-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/4.0.0-8257-update-mockito-SNAPSHOT/gravitee-bom-4.0.0-8257-update-mockito-SNAPSHOT.zip)
  <!-- Version placeholder end -->
