### PR TITLE
Major upgrade of Gravitee BOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
   setup_release:
     when:
       matches:
-        pattern:  "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
+        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
         value: << pipeline.git.tag >>
     jobs:
       - gravitee/setup_pom-release-config:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@2.5.0
+  gravitee: gravitee-io/gravitee@4.1.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,6 @@
     },
     {
       "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "branch",
       "semanticCommitType": "ci"

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2021 The Gravitee team (http://gravitee.io)
+    Copyright © 2021 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.0</version>
+        <version>22.0.0</version>
     </parent>
 
     <name>Gravitee.io - BOM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -61,24 +61,24 @@
 
     <properties>
         <assertj-core.version>3.24.2</assertj-core.version>
-        <jackson.version>2.14.2</jackson.version>
-        <jersey.version>3.1.1</jersey.version>
+        <jackson.version>2.14.3</jackson.version>
+        <jersey.version>3.1.2</jersey.version>
         <jetty.version>11.0.15</jetty.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.4.8</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
-        <mockito.version>5.3.1</mockito.version>
+        <mockito.version>5.4.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.87.Final</netty.version>
+        <netty.version>4.1.89.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.6</rxjava3.version>
-        <slf4j.version>1.7.36</slf4j.version>
-        <spring.version>6.0.9</spring.version>
-        <spring-security.version>6.1.0</spring-security.version>
-        <vertx.version>4.3.8</vertx.version>
-        <lombok.version>1.18.26</lombok.version>
+        <slf4j.version>2.0.7</slf4j.version>
+        <spring.version>6.0.10</spring.version>
+        <spring-security.version>6.1.1</spring-security.version>
+        <vertx.version>4.4.4</vertx.version>
+        <lombok.version>1.18.28</lombok.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,6 @@
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <netty.version>4.1.89.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
-        <rxjava2.version>2.2.21</rxjava2.version>
         <rxjava3.version>3.1.6</rxjava3.version>
         <slf4j.version>2.0.7</slf4j.version>
         <spring.version>6.0.10</spring.version>
@@ -218,11 +217,6 @@
                 <artifactId>logback-json-core</artifactId>
                 <version>${logback-json.version}</version>
                 <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.reactivex.rxjava2</groupId>
-                <artifactId>rxjava</artifactId>
-                <version>${rxjava2.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.reactivex.rxjava3</groupId>


### PR DESCRIPTION
**Issue**

N/A

**Description**

- Bump dependencies, mainly Vert.x and Logback
- Remove RxJava2 dependency, as RxJava3 is expected to be used instead
- Use the latest gravitee-parent `22.0.0`
- Bump gravitee-orb to `4.1.0`
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.0-upgrade-vertx-and-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/6.0.0-upgrade-vertx-and-deps-SNAPSHOT/gravitee-bom-6.0.0-upgrade-vertx-and-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
