### PR TITLE
fix: get the latest versions of jackson and netty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
     <properties>
         <assertj-core.version>3.24.2</assertj-core.version>
-        <jackson.version>2.14.3</jackson.version>
+        <jackson.version>2.15.2</jackson.version>
         <jersey.version>3.1.2</jersey.version>
         <jetty.version>11.0.15</jetty.version>
         <junit.version>4.13.2</junit.version>
@@ -70,7 +70,7 @@
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>5.4.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.89.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.6</rxjava3.version>
         <slf4j.version>2.0.7</slf4j.version>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Use the latest version of Jackson and Netty libraries
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.1-fix-bump-other-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/6.0.1-fix-bump-other-dependencies-SNAPSHOT/gravitee-bom-6.0.1-fix-bump-other-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
