### PR TITLE
feat: upgrade bom to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,28 +60,35 @@
     </organization>
 
     <properties>
-        <assertj-core.version>3.24.2</assertj-core.version>
-        <jackson.version>2.15.3</jackson.version>
-        <jersey.version>3.1.3</jersey.version>
-        <jetty.version>11.0.18</jetty.version>
+        <assertj-core.version>3.25.1</assertj-core.version>
+        <jackson.version>2.16.1</jackson.version>
+        <jersey.version>3.1.5</jersey.version>
+        <jetty.version>12.0.3</jetty.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.10.1</junit-jupiter.version>
         <logback.version>1.4.14</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>5.8.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.104.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.8</rxjava3.version>
-        <slf4j.version>2.0.9</slf4j.version>
-        <spring.version>6.0.13</spring.version>
-        <spring-security.version>6.1.5</spring-security.version>
-        <vertx.version>4.4.6</vertx.version>
+        <slf4j.version>2.0.10</slf4j.version>
+        <spring.version>6.1.2</spring.version>
+        <spring-security.version>6.2.1</spring-security.version>
+        <vertx.version>4.5.1</vertx.version>
         <lombok.version>1.18.30</lombok.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.eclipse.jetty.ee10</groupId>
+                <artifactId>jetty-ee10</artifactId>
+                <version>${jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
@@ -89,7 +96,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
             <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-296

**Description**

See diff to understand changes

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `7.0.0-archi-296-upgrade-bom-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/7.0.0-archi-296-upgrade-bom-SNAPSHOT/gravitee-bom-7.0.0-archi-296-upgrade-bom-SNAPSHOT.zip)
  <!-- Version placeholder end -->
