### PR TITLE
chore: disable renovate on 3.x branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "rebaseWhen": "conflicted",
-  "baseBranches": ["master", "3.x", "6.x"],
+  "baseBranches": ["master", "6.x"],
   "packageRules": [
     {
       "groupName": "Vert.x and related dependencies",


### PR DESCRIPTION
**Description**

Disable Renovate on 3.x to avoid automatic upgrade PRs that are irrelevant to this old version. 
Manual upgrades are possible if needed.
We encourage you to either use the latest 6.x or 7.x version.
