### PR TITLE
fix: upgrade spring to 6.0.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,13 +70,13 @@
         <logback-json.version>0.1.5</logback-json.version>
         <mockito.version>5.10.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.100.Final</netty.version>
+        <netty.version>4.1.106.Final</netty.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.8</rxjava3.version>
         <slf4j.version>2.0.12</slf4j.version>
         <spring.version>6.0.16</spring.version>
         <spring-security.version>6.1.6</spring-security.version>
-        <vertx.version>4.4.6</vertx.version>
+        <vertx.version>4.4.8</vertx.version>
         <lombok.version>1.18.30</lombok.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.8</rxjava3.version>
         <slf4j.version>2.0.12</slf4j.version>
-        <spring.version>6.0.13</spring.version>
+        <spring.version>6.0.16</spring.version>
         <spring-security.version>6.1.6</spring-security.version>
         <vertx.version>4.4.6</vertx.version>
         <lombok.version>1.18.30</lombok.version>


### PR DESCRIPTION
**Description**

Vertx Changelogs
- 4.4.8: https://github.com/vert-x3/wiki/wiki/4.4.8-Release-Notes
- 4.4.7: https://github.com/vert-x3/wiki/wiki/4.4.7-Release-Notes


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `6.0.32-upgrade-vertx-spring-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/6.0.32-upgrade-vertx-spring-SNAPSHOT/gravitee-bom-6.0.32-upgrade-vertx-spring-SNAPSHOT.zip)
  <!-- Version placeholder end -->
