### PR TITLE
feat: add opentelemetry BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <vertx.version>4.5.7</vertx.version>
         <lombok.version>1.18.32</lombok.version>
         <bouncycastle.version>1.78</bouncycastle.version>
+        <opentelemetry.version>1.39.0</opentelemetry.version>
     </properties>
 
     <dependencyManagement>
@@ -165,6 +166,14 @@
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
                 <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5276

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.1.0-APIM-5276-otel-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.1.0-APIM-5276-otel-SNAPSHOT/gravitee-bom-8.1.0-APIM-5276-otel-SNAPSHOT.zip)
  <!-- Version placeholder end -->
