### PR TITLE
fix: reorder boms to load the right JUnit version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10</artifactId>
                 <version>${jetty.version}</version>
@@ -154,13 +161,6 @@
                 <scope>import</scope>
             </dependency>
 
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit-jupiter.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
**Description**

The latest version of the BOM containing the update of JUnit is not usable: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-federation-agent/935/workflows/5309f5db-8acf-40dc-8b26-b4d3503256e3/jobs/6534

After some investigation, it seems that the bom import of `org.eclipse.jetty.ee10.jetty-ee10` is overriding the JUnit version to load. As we can see in Maven Repository's report the dependency declares 5.10.3 version : https://mvnrepository.com/artifact/org.eclipse.jetty.ee10/jetty-ee10/12.0.13
![image](https://github.com/user-attachments/assets/e984995d-2a1d-476d-8b7d-0ca2a07cc6f5)

If we declare JUnit BOM import before `org.eclipse.jetty.ee10.jetty-ee10` it seems to load the version 5.11.0

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

