### PR TITLE
chore: upgrade spring security to 6.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <rxjava3.version>3.1.9</rxjava3.version>
         <slf4j.version>2.0.16</slf4j.version>
         <spring.version>6.1.14</spring.version>
-        <spring-security.version>6.2.4</spring-security.version>
+        <spring-security.version>6.2.7</spring-security.version>
         <vertx.version>4.5.10</vertx.version>
         <lombok.version>1.18.34</lombok.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.1.17`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.1.17/gravitee-bom-8.1.17.zip)
  <!-- Version placeholder end -->
