### PR TITLE
fix: update vertx version to include websocket fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <slf4j.version>2.0.16</slf4j.version>
         <spring.version>6.1.14</spring.version>
         <spring-security.version>6.2.7</spring-security.version>
-        <vertx.version>4.5.10</vertx.version>
+        <vertx.version>4.5.11</vertx.version>
         <lombok.version>1.18.36</lombok.version>
         <bouncycastle.version>1.78.1</bouncycastle.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-6884

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.1.19-apim-6884-upgrade-vertx-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.1.19-apim-6884-upgrade-vertx-version-SNAPSHOT/gravitee-bom-8.1.19-apim-6884-upgrade-vertx-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
