### PR TITLE
chore: declare testcontainers version for all projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
 
     <properties>
         <assertj-core.version>3.26.3</assertj-core.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
         <jackson.version>2.17.2</jackson.version>
         <jersey.version>3.1.8</jersey.version>
         <jetty.version>12.0.13</jetty.version>
@@ -68,18 +69,18 @@
         <junit-jupiter.version>5.11.1</junit-jupiter.version>
         <logback.version>1.5.8</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
+        <lombok.version>1.18.36</lombok.version>
         <mockito.version>5.13.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <netty.version>4.1.113.Final</netty.version>
+        <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.10</rxjava3.version>
         <slf4j.version>2.0.16</slf4j.version>
         <spring.version>6.1.14</spring.version>
         <spring-security.version>6.2.7</spring-security.version>
+        <testcontainers.version>1.20.4</testcontainers.version>
         <vertx.version>4.5.11</vertx.version>
-        <lombok.version>1.18.36</lombok.version>
-        <bouncycastle.version>1.78.1</bouncycastle.version>
-        <opentelemetry.version>1.39.0</opentelemetry.version>
     </properties>
 
     <dependencyManagement>
@@ -91,6 +92,15 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.eclipse.jetty.ee10</groupId>
                 <artifactId>jetty-ee10</artifactId>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Testcontainers is more and more used, especially with the kafka gateway project but still imported in different version depending on the project (gravitee-node => 1.19.3, apim endpoints/entrypoints => 1.20.2 or 1.19.8)

The idea here is to use the latest version available (1.20.4) for all our tests.

Starting with TestContainers 1.20.2, it now possible to test with ApacheKafka container or with a ConfluentKakfa container more easily, providing useful methods to configure them.

https://github.com/testcontainers/testcontainers-java/releases
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.2.0-declare-testcontainer-version-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.2.0-declare-testcontainer-version-SNAPSHOT/gravitee-bom-8.2.0-declare-testcontainer-version-SNAPSHOT.zip)
  <!-- Version placeholder end -->
