### PR TITLE
chore: update renovate config (added 7.x branch and removed 3.x)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "rebaseWhen": "conflicted",
-  "baseBranches": ["master", "6.x", "3.x"],
+  "baseBranches": ["master", "7.x", "6.x"],
   "packageRules": [
     {
       "groupName": "Vert.x and related dependencies",
@@ -54,6 +54,41 @@
       "semanticCommitType": "fix"
     },
     {
+      "matchBaseBranches": ["7.x"],
+      "matchPackagePatterns": ["org.springframework:spring-framework-bom"],
+      "allowedVersions": "<=6.1",
+      "automerge": false,
+      "automergeType": "branch",
+      "semanticCommitType": "fix"
+    },
+    {
+      "matchBaseBranches": ["7.x"],
+      "matchPackagePatterns": [
+        "org.springframework.security:spring-security-bom"
+      ],
+      "allowedVersions": "<=6.2",
+      "automerge": false,
+      "automergeType": "branch",
+      "semanticCommitType": "fix"
+    },
+    {
+      "matchBaseBranches": ["7.x"],
+      "matchPackagePatterns": ["io.vertx:vertx-*"],
+      "allowedVersions": "<=4.5",
+      "automerge": false,
+      "automergeType": "branch",
+      "semanticCommitType": "fix"
+    },
+    {
+      "matchBaseBranches": ["7.x"],
+      "groupName": "Vert.x and related dependencies",
+      "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": false,
+      "automergeType": "branch",
+      "semanticCommitType": "fix"
+    },
+    {
       "matchBaseBranches": ["6.x"],
       "matchPackagePatterns": ["org.springframework:spring-framework-bom"],
       "allowedVersions": "<=6.0",
@@ -81,41 +116,6 @@
     },
     {
       "matchBaseBranches": ["6.x"],
-      "groupName": "Vert.x and related dependencies",
-      "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["3.x"],
-      "matchPackagePatterns": ["org.springframework:spring-framework-bom"],
-      "allowedVersions": "<=5.3",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["3.x"],
-      "matchPackagePatterns": [
-        "org.springframework.security:spring-security-bom"
-      ],
-      "allowedVersions": "<=5.5",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["3.x"],
-      "matchPackagePatterns": ["io.vertx:vertx-*"],
-      "allowedVersions": "<=4.2",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["3.x"],
       "groupName": "Vert.x and related dependencies",
       "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-300

**Description**

Renovate config update to remove 3.x branch not maintained anymore and add 7.x which was missing.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.2.5`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.2.5/gravitee-bom-8.2.5.zip)
  <!-- Version placeholder end -->
