### PR TITLE
Renovate configuration improvments

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": ["config:base"],
   "rebaseWhen": "conflicted",
-  "baseBranches": ["master", "7.x", "6.x"],
+  "baseBranches": ["master"],
   "packageRules": [
     {
       "groupName": "Vert.x and related dependencies",
@@ -50,76 +50,6 @@
       "matchPackagePatterns": ["org.junit:*", "org.mockito:*"],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["7.x"],
-      "matchPackagePatterns": ["org.springframework:spring-framework-bom"],
-      "allowedVersions": "<=6.1",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["7.x"],
-      "matchPackagePatterns": [
-        "org.springframework.security:spring-security-bom"
-      ],
-      "allowedVersions": "<=6.2",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["7.x"],
-      "matchPackagePatterns": ["io.vertx:vertx-*"],
-      "allowedVersions": "<=4.5",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["7.x"],
-      "groupName": "Vert.x and related dependencies",
-      "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["6.x"],
-      "matchPackagePatterns": ["org.springframework:spring-framework-bom"],
-      "allowedVersions": "<=6.0",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["6.x"],
-      "matchPackagePatterns": [
-        "org.springframework.security:spring-security-bom"
-      ],
-      "allowedVersions": "<=6.1",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["6.x"],
-      "matchPackagePatterns": ["io.vertx:vertx-*"],
-      "allowedVersions": "<=4.4",
-      "automerge": false,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchBaseBranches": ["6.x"],
-      "groupName": "Vert.x and related dependencies",
-      "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"],
-      "matchUpdateTypes": ["patch"],
-      "automerge": false,
       "automergeType": "branch",
       "semanticCommitType": "fix"
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
-  "extends": ["config:base"],
-  "rebaseWhen": "conflicted",
+  "extends": ["github>gravitee-io/renovate-config", "config:base"],
   "baseBranches": ["master"],
   "packageRules": [
     {
@@ -8,18 +7,11 @@
       "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"]
     },
     {
-      "matchDatasources": ["orb"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
       "matchPackagePatterns": [
         "org.projectlombok:*",
         "io.reactivex.rxjava2:*",
         "io.reactivex.rxjava3:*",
-        "org.reactivestreams:*",
-        "io.gravitee:gravitee-parent"
+        "org.reactivestreams:*"
       ],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
@@ -35,13 +27,6 @@
         "ch.qos.logback:*"
       ],
       "matchUpdateTypes": ["patch"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
-      "matchDepTypes": ["test"],
-      "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "branch",
       "semanticCommitType": "fix"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,22 +3,12 @@
   "baseBranches": ["master"],
   "packageRules": [
     {
+      // Group Vert.x & Netty related dependencies together
       "groupName": "Vert.x and related dependencies",
       "matchPackagePatterns": ["io.vertx:vertx-*", "io.netty:*"]
     },
     {
-      "matchPackagePatterns": [
-        "org.projectlombok:*",
-        "io.reactivex.rxjava2:*",
-        "io.reactivex.rxjava3:*",
-        "org.reactivestreams:*"
-      ],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "fix"
-    },
-    {
+      // Merge automatically minor and patch updates for Spring, Jackson and logging related dependencies
       "matchPackagePatterns": [
         "org.springframework:spring-framework-bom",
         "org.springframework.security:spring-security-bom",
@@ -32,7 +22,14 @@
       "semanticCommitType": "fix"
     },
     {
-      "matchPackagePatterns": ["org.junit:*", "org.mockito:*"],
+      // Merge automatically minor and patch updates for the following dependencies
+      "matchPackagePatterns": [
+        "org.projectlombok:*",
+        "io.reactivex.rxjava3:*",
+        "org.reactivestreams:*",
+        "org.junit:*",
+        "org.mockito:*"
+      ],
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
       "automergeType": "branch",


### PR DESCRIPTION
**Description**

- Drop support for 6.x and 7.x version. Those versions are not used anymore. 
  - 7.x is used by APIM 4.3 but EOL is coming when APIM 4.7 will be released (end of march). 
  - AM does not use 7.x anymore

- Use the Gravitee preset.

- Use json5 extension to allow comments to explain rules


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

