### PR TITLE
Revert "fix(deps): update io.opentelemetry:opentelemetry-bom to v1.48.0"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,8 +14,7 @@
         "org.springframework.security:spring-security-bom",
         "org.slf4j:*",
         "com.fasterxml.jackson:*",
-        "ch.qos.logback:*",
-        "io.opentelemetry:*"
+        "ch.qos.logback:*"
       ],
       "matchUpdateTypes": ["patch"],
       "automerge": true,
@@ -35,6 +34,13 @@
       "automerge": true,
       "automergeType": "branch",
       "semanticCommitType": "fix"
+    },
+    {
+      // Ignore update of opentelemetry until https://gravitee.atlassian.net/browse/ARCHI-486
+      "matchPackagePatterns": [
+        "io.opentelemetry:opentelemetry-bom"
+      ],
+      "enable": false
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <mockito.version>5.16.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
         <netty.version>4.1.118.Final</netty.version>
-        <opentelemetry.version>1.48.0</opentelemetry.version>
+        <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.10</rxjava3.version>
         <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
**Description**

Revert opentelemetry to 1.39 again. 
We must find a way to prevent Renovate from automatically updating without approval. The last attempt was a failure 😢.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.2.21-revert-opentelemetry-to-v1-39-again-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.2.21-revert-opentelemetry-to-v1-39-again-SNAPSHOT/gravitee-bom-8.2.21-revert-opentelemetry-to-v1-39-again-SNAPSHOT.zip)
  <!-- Version placeholder end -->
