### PR TITLE
fix: update spring security to 6.4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <rxjava3.version>3.1.10</rxjava3.version>
         <slf4j.version>2.0.17</slf4j.version>
         <spring.version>6.2.3</spring.version>
-        <spring-security.version>6.4.3</spring-security.version>
+        <spring-security.version>6.4.4</spring-security.version>
         <testcontainers.version>1.20.6</testcontainers.version>
         <vertx.version>4.5.13</vertx.version>
     </properties>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.2.22-upgrade-spring-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.2.22-upgrade-spring-SNAPSHOT/gravitee-bom-8.2.22-upgrade-spring-SNAPSHOT.zip)
  <!-- Version placeholder end -->
