### PR TITLE
feat: add log4j-to-slf4j in dependency management (needed for librari…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.10</rxjava3.version>
         <slf4j.version>2.0.17</slf4j.version>
+        <log4j-to-slf4j.version>2.24.3</log4j-to-slf4j.version>
         <spring.version>6.2.3</spring.version>
         <spring-security.version>6.4.4</spring-security.version>
         <testcontainers.version>1.20.6</testcontainers.version>
@@ -309,6 +310,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+                <version>${log4j-to-slf4j.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
…es using log4j-api)

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-495

**Description**

Add log4j-to-slf4j in dependency management which is needed in case some libraries are using log4j-api instead of slf4j.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.0-feat-add-log4j-bridge-to-slf4j-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.0-feat-add-log4j-bridge-to-slf4j-SNAPSHOT/gravitee-bom-8.3.0-feat-add-log4j-bridge-to-slf4j-SNAPSHOT.zip)
  <!-- Version placeholder end -->
