### PR TITLE
chore: fix renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -40,7 +40,7 @@
       "matchPackagePatterns": [
         "io.opentelemetry:opentelemetry-bom"
       ],
-      "enable": false
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

It seems that the `enable` is not accepted anymore in Renovate. Here is the error message that we have :

> Source: .github/renovate.json5
> Reason: The renovate configuration file contains some invalid settings
> Message: Invalid configuration option: packageRules[3].enable

In the documentation, it seems that we need to use `enabled` (https://docs.renovatebot.com/configuration-options/#enabled)

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.0/gravitee-bom-8.3.0.zip)
  <!-- Version placeholder end -->
