### PR TITLE
fix(deps): upgrade vertx 4.5.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <lombok.version>1.18.38</lombok.version>
         <mockito.version>5.18.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.118.Final</netty.version>
+        <netty.version>4.1.124.Final</netty.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.11</rxjava3.version>
@@ -83,7 +83,7 @@
         <spring.version>6.2.9</spring.version>
         <spring-security.version>6.5.2</spring-security.version>
         <testcontainers.version>1.21.3</testcontainers.version>
-        <vertx.version>4.5.13</vertx.version>
+        <vertx.version>4.5.18</vertx.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-569

**Description**

Upgrade Vertx to 4.5.18 and Netty 4.1.124.Final.
(No breaking change between 4.5.13 and 4.5.18)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.30-archi-569-upgrade-vertx-4-5-18-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.30-archi-569-upgrade-vertx-4-5-18-SNAPSHOT/gravitee-bom-8.3.30-archi-569-upgrade-vertx-4-5-18-SNAPSHOT.zip)
  <!-- Version placeholder end -->
