### PR TITLE
fix(deps): upgrade vertx 4.5.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <lombok.version>1.18.40</lombok.version>
         <mockito.version>5.19.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.124.Final</netty.version>
+        <netty.version>4.1.126.Final</netty.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.11</rxjava3.version>
@@ -83,7 +83,7 @@
         <spring.version>6.2.10</spring.version>
         <spring-security.version>6.5.3</spring-security.version>
         <testcontainers.version>1.21.3</testcontainers.version>
-        <vertx.version>4.5.18</vertx.version>
+        <vertx.version>4.5.21</vertx.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-580

**Description**

Upgrade Vertx to 4.5.21 and Netty 4.1.126.Final.
(No breaking change between 4.5.18 and 4.5.21)



<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.38-fix-upgrade-vertx-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.38-fix-upgrade-vertx-SNAPSHOT/gravitee-bom-8.3.38-fix-upgrade-vertx-SNAPSHOT.zip)
  <!-- Version placeholder end -->
