### PR TITLE
fix(deps): Downgrade netty to 4.1.124.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <lombok.version>1.18.42</lombok.version>
         <mockito.version>5.20.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.126.Final</netty.version>
+        <netty.version>4.1.124.Final</netty.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.12</rxjava3.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**
after upgrading Netty to version 4.1.125.Final throughput dropped to about 1,000 RPS, whereas with version 4.1.124.Final we achieved around 2,500 RPS

related to https://github.com/netty/netty/issues/15852 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.47-APIM-11985-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.47-APIM-11985-SNAPSHOT/gravitee-bom-8.3.47-APIM-11985-SNAPSHOT.zip)
  <!-- Version placeholder end -->
