### PR TITLE
fix: bump testcontainer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <log4j-to-slf4j.version>2.25.1</log4j-to-slf4j.version>
         <spring.version>6.2.11</spring.version>
         <spring-security.version>6.5.5</spring-security.version>
-        <testcontainers.version>1.21.3</testcontainers.version>
+        <testcontainers.version>2.0.3</testcontainers.version>
         <vertx.version>4.5.21</vertx.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

To ensure our testcontainer tests are compatible with latest docker engine
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-bump-test-containers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/9.0.0-bump-test-containers-SNAPSHOT/gravitee-bom-9.0.0-bump-test-containers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
