### PR TITLE
feat: major upgrade of vertx (5.x) and Netty (4.2.x)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <lombok.version>1.18.42</lombok.version>
         <mockito.version>5.20.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.124.Final</netty.version>
+        <netty.version>4.2.10.Final</netty.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.12</rxjava3.version>
@@ -83,7 +83,7 @@
         <spring.version>6.2.11</spring.version>
         <spring-security.version>6.5.5</spring-security.version>
         <testcontainers.version>2.0.3</testcontainers.version>
-        <vertx.version>4.5.21</vertx.version>
+        <vertx.version>5.0.8</vertx.version>
     </properties>
 
     <dependencyManagement>
@@ -143,6 +143,16 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-base</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-compression</artifactId>
                 <version>${netty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
BREAKING CHANGE: upgrade vertx to 5.0.x

**Issue**

https://gravitee.atlassian.net/browse/ARCHI-601

**Description**

Prepare Vertx 5 upgrade.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-alpha-vertx5-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/9.0.0-alpha-vertx5-SNAPSHOT/gravitee-bom-9.0.0-alpha-vertx5-SNAPSHOT.zip)
  <!-- Version placeholder end -->
