### PR TITLE
AM-6911 - fix(deps): update jetty to 12.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <bouncycastle.version>1.81</bouncycastle.version>
         <jackson.version>2.20.0</jackson.version>
         <jersey.version>3.1.11</jersey.version>
-        <jetty.version>12.1.1</jetty.version>
+        <jetty.version>12.1.8</jetty.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.14.0</junit-jupiter.version>
         <logback.version>1.5.18</logback.version>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/AM-6911

**Description**

Updates Jetty to 12.1.8 to resolve CVE-2026-1605

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.50-AM-6911-jetty-server-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.50-AM-6911-jetty-server-upgrade-SNAPSHOT/gravitee-bom-8.3.50-AM-6911-jetty-server-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
