### PR TITLE
fix: bump spring security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <log4j-to-slf4j.version>2.25.1</log4j-to-slf4j.version>
         <spring.version>6.2.17</spring.version>
-        <spring-security.version>6.5.9</spring-security.version>
+        <spring-security.version>6.5.10</spring-security.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <vertx.version>4.5.26</vertx.version>
     </properties>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13800

**Description**

to fix CVEs.
See: https://spring.io/blog/2026/04/21/spring-security-releases


<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.51-bump-spring-security-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.51-bump-spring-security-SNAPSHOT/gravitee-bom-8.3.51-bump-spring-security-SNAPSHOT.zip)
  <!-- Version placeholder end -->
