### PR TITLE
fix: upgrade nettyto 4.1.133 and vertx to 4.5.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <lombok.version>1.18.46</lombok.version>
         <mockito.version>5.23.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.12</rxjava3.version>
@@ -83,7 +83,7 @@
         <spring.version>6.2.18</spring.version>
         <spring-security.version>6.5.10</spring-security.version>
         <testcontainers.version>1.21.4</testcontainers.version>
-        <vertx.version>4.5.26</vertx.version>
+        <vertx.version>4.5.27</vertx.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.61-chore-bump-vertxnetty-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.61-chore-bump-vertxnetty-SNAPSHOT/gravitee-bom-8.3.61-chore-bump-vertxnetty-SNAPSHOT.zip)
  <!-- Version placeholder end -->
