### PR TITLE
fix: upgrade nettyto 4.2.13 and vertx to 5.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <lombok.version>1.18.42</lombok.version>
         <mockito.version>5.20.0</mockito.version>
         <mockito-inline.version>5.2.0</mockito-inline.version>
-        <netty.version>4.2.12.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
         <opentelemetry.version>1.39.0</opentelemetry.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
         <rxjava3.version>3.1.12</rxjava3.version>
@@ -83,7 +83,7 @@
         <spring.version>6.2.17</spring.version>
         <spring-security.version>6.5.9</spring-security.version>
         <testcontainers.version>2.0.3</testcontainers.version>
-        <vertx.version>5.0.10</vertx.version>
+        <vertx.version>5.0.12</vertx.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.0-chore-bump-vertx5netty-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/9.0.0-chore-bump-vertx5netty-SNAPSHOT/gravitee-bom-9.0.0-chore-bump-vertx5netty-SNAPSHOT.zip)
  <!-- Version placeholder end -->
