### PR TITLE
fix: upgrade spring to 6.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <rxjava3.version>3.1.12</rxjava3.version>
         <slf4j.version>2.0.18</slf4j.version>
         <log4j-to-slf4j.version>2.26.0</log4j-to-slf4j.version>
-        <spring.version>6.2.18</spring.version>
+        <spring.version>6.2.19</spring.version>
         <spring-security.version>6.5.10</spring-security.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <vertx.version>4.5.28</vertx.version>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.63-chore-spring-6-2-19-8-3-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.63-chore-spring-6-2-19-8-3-x-SNAPSHOT/gravitee-bom-8.3.63-chore-spring-6-2-19-8-3-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
