### PR TITLE
fix: bump jackson to solve CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <assertj-core.version>3.27.7</assertj-core.version>
         <bouncycastle.version>1.84</bouncycastle.version>
-        <jackson.version>2.21.3</jackson.version>
+        <jackson.version>2.21.4</jackson.version>
         <jersey.version>3.1.11</jersey.version>
         <jetty.version>12.1.9</jetty.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `9.0.2-chore-jackson-2-21-4-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/9.0.2-chore-jackson-2-21-4-SNAPSHOT/gravitee-bom-9.0.2-chore-jackson-2-21-4-SNAPSHOT.zip)
  <!-- Version placeholder end -->
