### PR TITLE
fix(deps): update org.springframework.security:spring-security-bom to 6.5.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <slf4j.version>2.0.18</slf4j.version>
         <log4j-to-slf4j.version>2.26.0</log4j-to-slf4j.version>
         <spring.version>6.2.19</spring.version>
-        <spring-security.version>6.5.10</spring-security.version>
+        <spring-security.version>6.5.11</spring-security.version>
         <testcontainers.version>1.21.4</testcontainers.version>
         <vertx.version>4.5.28</vertx.version>
     </properties>


### PR DESCRIPTION
fixes https://github.com/advisories/GHSA-293q-567p-wmwq

https://app.opencve.io/cve/CVE-2026-47838

linked to https://gravitee.atlassian.net/browse/AM-7202
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `8.3.65-fix-8-3-spring-security-6-5-11-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/gravitee-bom/8.3.65-fix-8-3-spring-security-6-5-11-SNAPSHOT/gravitee-bom-8.3.65-fix-8-3-spring-security-6-5-11-SNAPSHOT.zip)
  <!-- Version placeholder end -->
